### PR TITLE
Fix assertpy.py and some tests for Windows environment

### DIFF
--- a/assertpy/assertpy.py
+++ b/assertpy/assertpy.py
@@ -55,22 +55,22 @@ __tracebackhide__ = True  # clean tracebacks via py.test integration
 contextlib.__tracebackhide__ = True  # monkey patch contextlib with clean py.test tracebacks
 
 # assertpy files
-ASSERTPY_FILES = [
-    'assertpy/assertpy.py',
-    'assertpy/base.py',
-    'assertpy/collection.py',
-    'assertpy/contains.py',
-    'assertpy/date.py',
-    'assertpy/dict.py',
-    'assertpy/dynamic.py',
-    'assertpy/exception.py',
-    'assertpy/extracting.py',
-    'assertpy/file.py',
-    'assertpy/helpers.py',
-    'assertpy/numeric.py',
-    'assertpy/snapshot.py',
-    'assertpy/string.py'
-]
+ASSERTPY_FILES = [os.path.join('assertpy', file) for file in [
+    'assertpy.py',
+    'base.py',
+    'collection.py',
+    'contains.py',
+    'date.py',
+    'dict.py',
+    'dynamic.py',
+    'exception.py',
+    'extracting.py',
+    'file.py',
+    'helpers.py',
+    'numeric.py',
+    'snapshot.py',
+    'string.py'
+]]
 
 # soft assertions
 _soft_ctx = 0

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -28,18 +28,16 @@
 
 import sys
 import os
-import tempfile
 import pytest
 from assertpy import assert_that, contents_of, fail
 
 
 @pytest.fixture()
-def tmpfile():
-    tmp = tempfile.NamedTemporaryFile()
+def tmpfile(tmpdir):
+    tmp = tmpdir.join('test.txt')
     tmp.write('foobar'.encode('utf-8'))
-    tmp.seek(0)
-    yield tmp
-    tmp.close()
+    with tmp.open('rb') as f:
+        yield f
 
 
 def test_contents_of_path(tmpfile):
@@ -71,12 +69,12 @@ def test_contents_of_return_type_ascii(tmpfile):
 
 
 def test_contents_of_file(tmpfile):
-    contents = contents_of(tmpfile.file)
+    contents = contents_of(tmpfile)
     assert_that(contents).is_equal_to('foobar').starts_with('foo').ends_with('bar')
 
 
 def test_contents_of_file_ascii(tmpfile):
-    contents = contents_of(tmpfile.file, 'ascii')
+    contents = contents_of(tmpfile, 'ascii')
     assert_that(contents).is_equal_to('foobar').starts_with('foo').ends_with('bar')
 
 
@@ -210,7 +208,7 @@ def test_is_child_of_failure(tmpfile):
         assert_that(tmpfile.name).is_child_of('foo_dir')
         fail('should have raised error')
     except AssertionError as ex:
-        assert_that(str(ex)).matches('Expected file <.*> to be a child of <.*/foo_dir>, but was not.')
+        assert_that(str(ex)).matches(r'Expected file <.*> to be a child of <.*[\\/]foo_dir>, but was not.')
 
 
 def test_is_child_of_bad_arg_type_failure(tmpfile):


### PR DESCRIPTION
Two fixes for Windows environment:
* `/` is not proper separator on Windows, so os.path.join should be called to build proper path
* `NamedTemporaryFile` has different behaviour on Unix and Windows as stated in [docs](https://docs.python.org/3.8/library/tempfile.html#tempfile.NamedTemporaryFile), so I've used `tmpdir` fixture from pytest

You should also consider adding Windows build (like Cirrus CI which is free for open source). I'm going to experiment with Cirrus CI in my own package, so if you willing to wait, I can prepare this config one day. 