### PR TITLE
Handle multivalued tuples without error

### DIFF
--- a/assertpy/helpers.py
+++ b/assertpy/helpers.py
@@ -47,7 +47,7 @@ class HelpersMixin(object):
         if len(i) == 0:
             return '<>'
         elif len(i) == 1 and hasattr(i, '__getitem__'):
-            return '<%s>' % i[0]
+            return '<%s>' % (i[0],)
         else:
             return '<%s>' % str(i).lstrip('([').rstrip(',])')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,6 +38,7 @@ def test_fmt_items_single():
     ab = assert_that(None)
     assert_that(ab._fmt_items([1])).is_equal_to('<1>')
     assert_that(ab._fmt_items(['foo'])).is_equal_to('<foo>')
+    assert_that(ab._fmt_items([('bar', 'baz')])).is_equal_to('<(\'bar\', \'baz\')>')
 
 
 def test_fmt_items_multiple():


### PR DESCRIPTION
Hello,

I'm a enthusiast user of your library and I use it a lot in all my python projects. Thank you for writing it!

I run into a little bug when using contains assertion with one tuple matching, and not the other:
```python
assert_that([('key', 'value')]).contains(
    ('missing_key', 'missing_value''), 
    ('key', 'value')
)
```
I found this Stack Overflow thread: https://stackoverflow.com/questions/1455602/printing-tuple-with-string-formatting-in-python which reference this formatting limitation, and I used the proposed fix.