### PR TITLE
Fix chaining failure in `raises` soft assertion (#130)

### DIFF
--- a/assertpy/assertpy.py
+++ b/assertpy/assertpy.py
@@ -42,7 +42,7 @@ from .date import DateMixin
 from .dict import DictMixin
 from .dynamic import DynamicMixin
 from .extracting import ExtractingMixin
-from .exception import ExceptionMixin
+from .exception import ExceptionMixin, _NoChainingMixin
 from .file import FileMixin
 from .helpers import HelpersMixin
 from .numeric import NumericMixin
@@ -456,6 +456,10 @@ class AssertionBuilder(
             return self
         elif self.kind == 'soft':
             global _soft_err
+            if callable(self.val):
+                # replace all callable methods of AssertionBuilder instance with empty function if self.val is callable
+                self.__class__ = type(self.__class__.__name__, (self.__class__, _NoChainingMixin), {})
+                out += " Any further chain assertions ignored."
             _soft_err.append(out)
             return self
         else:

--- a/assertpy/exception.py
+++ b/assertpy/exception.py
@@ -111,3 +111,16 @@ class ExceptionMixin(object):
             self.val.__name__,
             self.expected.__name__,
             self._fmt_args_kwargs(*some_args, **some_kwargs)))
+
+
+class _NoChainingMixin(object):
+    """Mixin that replaces all method calls with empty function."""
+    def __getattribute__(self, item):
+        attr = super().__getattribute__(item)
+        if callable(attr) and item != "_do_nothing":
+            return self._do_nothing
+        return attr
+
+    def _do_nothing(self, *args, **kwargs):
+        """Method that is used instead of all callable attributes of AssertionBuilder"""
+        return self

--- a/tests/test_soft.py
+++ b/tests/test_soft.py
@@ -111,6 +111,30 @@ def test_expected_exception_failure():
         assert_that(out).contains("Expected <func_ok> to raise <RuntimeError> when called with ('baz').")
 
 
+def test_expected_exception_failure_chaining():
+    try:
+        with soft_assertions():
+            # No exception
+            assert_that(func_ok).raises(RuntimeError).when_called_with('a').is_equal_to('dog').matches('cat')
+            # Exception type mismatch
+            assert_that(func_ok).raises(TypeError).when_called_with('a').contains('dog')
+            # Error message mismatch
+            assert_that(func_err).raises(RuntimeError).when_called_with('a').matches('dog')
+        fail('should have raised error')
+    except AssertionError as ex:
+        out = str(ex)
+        assert_that(out).contains(
+            "1. Expected <func_ok> to raise <RuntimeError> when called with ('a')."
+            " Any further chain assertions ignored."
+        )
+        assert_that(out).contains(
+            "2. Expected <func_ok> to raise <TypeError> when called with ('a')."
+            " Any further chain assertions ignored."
+        )
+        assert_that(out).contains("3. Expected <err> to match pattern <dog>, but did not.")
+        assert_that(out).does_not_contain("4.")
+
+
 def func_ok(arg):
     pass
 


### PR DESCRIPTION
Please have a look at this bug:
https://github.com/assertpy/assertpy/issues/130

This PR prevents program from failing in described scenarios. It replaces all callable attributes of `AssertionBuilder` *instance* with some empty function that returns `self`. So any chaining assertion of current `AssertionBuilder` instance will be ignored and won't cause failures.

Also it notifies users about about ignoring any further chaining assertions.

Example:
```python
with assertpy.soft_assertions():
    # No exception
    assertpy.assert_that(lambda x: 1/x).raises(ZeroDivisionError).when_called_with(1).is_equal_to('dog').matches('cat')
    # Exception type mismatch
    assertpy.assert_that({}.__getitem__).raises(RuntimeError).when_called_with('a').contains('dog')
    # Error message mismatch
    assertpy.assert_that(lambda x: 1/x).raises(ZeroDivisionError).when_called_with(0).matches('dog')
```
Output:
```
AssertionError: soft assertion failures:
1. Expected <<lambda>> to raise <ZeroDivisionError> when called with (1). Any further chain assertions ignored.
2. Expected <__getitem__> to raise <RuntimeError> when called with ('a'), but raised <KeyError>. Any further chain assertions ignored.
3. Expected <division by zero> to match pattern <dog>, but did not.
```