### PR TITLE
extracting: Support filter=None and sort=None

### DIFF
--- a/assertpy/extracting.py
+++ b/assertpy/extracting.py
@@ -209,7 +209,7 @@ class ExtractingMixin(object):
                     return True
                 elif callable(kwargs['filter']):
                     return kwargs['filter'](x)
-                return False
+                return kwargs['filter'] is None
             return True
 
         def _sort(x):

--- a/tests/test_extracting.py
+++ b/tests/test_extracting.py
@@ -150,6 +150,10 @@ def test_extracting_filter():
     assert_that(users).extracting('user', filter=lambda x: x['age'] < 10).is_empty()
 
 
+def test_extracting_filter_none():
+    assert_that(users).extracting('user', filter=None).is_equal_to(['Fred', 'Bob', 'Johnny'])
+
+
 def test_extracting_filter_bad_type():
     assert_that(users).extracting('user', filter=123).is_equal_to([])
 
@@ -229,6 +233,10 @@ def test_extracting_sort():
     assert_that(users).extracting('user', sort=['active', 'age']).is_equal_to(['Bob', 'Johnny', 'Fred'])
     assert_that(users).extracting('user', sort=('active', 'age')).is_equal_to(['Bob', 'Johnny', 'Fred'])
     assert_that(users).extracting('user', sort=lambda x: -x['age']).is_equal_to(['Bob', 'Fred', 'Johnny'])
+
+
+def test_extracting_sort_none():
+    assert_that(users).extracting('user', sort=None).is_equal_to(['Fred', 'Bob', 'Johnny'])
 
 
 def test_extracting_sort_ignore_bad_type():


### PR DESCRIPTION
Allow filter and sort kwargs to have values None which are equivalent to not specifying the kwargs.

sort=None already worked in this manner. A small code change was needed to support filter=None.

Test methods are added.