### PR TITLE
Add extract path functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,12 +742,76 @@ assert_that(example_nested_blob).extract_path(2, 'instance', 'name').is_equal_to
 assert_that(example_nested_blob).extract_path(2, 'instance', 'children').has_Bob(3).has_Alice(5)
 ```
 
-Simultaneously any discrepancies between the given path and value structure will be reported and runtime errors will be avoided.
-For example a typo in attribute name `children` will produce:
- 
+At the same time any discrepancies between the given path and value structure will be reported and runtime errors will be avoided.
+For example given following json response:
+
+```py
+api_response = {
+  "jsonapi": { "version": "1.1" },
+  "errors": [
+    {
+      "code":   "123",
+      "source": { "pointer": "/data/attributes/firstName" },
+      "title":  "Value is too short",
+      "detail": "First name must contain at least two characters."
+    },
+    {
+      "code":   "225",
+      "source": { "pointer": "/data/attributes/password" },
+      "title": "Passwords must contain a letter, number, and punctuation character.",
+      "detail": "The password provided is missing a punctuation character."
+    },
+    {
+      "code":   "226",
+      "source": { "pointer": "/data/attributes/password" },
+      "title": "Password and password confirmation do not match."
+    }
+  ]
+}
 ```
->       assert_that(example_nested_blob).extract_path(2, 'instance', 'Children', 'Bob').is_equal_to(3)
-E       AssertionError: invalid extraction key <Children> for value at path depth 2
+
+And assertion:
+
+```py
+from json import dumps
+
+assert_that(api_response, dumps(api_response, indent=4)).extract_path('errors', 1, 'source', 'pointer').is_equal_to('/data/attributes/password')
+```
+
+Replacing key name `source` with 'sauce', and json dumping blob for readability, will produce useful outputs like:
+
+```
+>       assert_that(api_response, dumps(api_response, indent=4)).extract_path('errors', 1, 'sauce', 'pointer').is_equal_to('/data/attributes/password')
+E       AssertionError: [{
+E           "jsonapi": {
+E               "version": "1.1"
+E           },
+E           "errors": [
+E               {
+E                   "code": "123",
+E                   "source": {
+E                       "pointer": "/data/attributes/firstName"
+E                   },
+E                   "title": "Value is too short",
+E                   "detail": "First name must contain at least two characters."
+E               },
+E               {
+E                   "code": "225",
+E                   "source": {
+E                       "pointer": "/data/attributes/password"
+E                   },
+E                   "title": "Passwords must contain a letter, number, and punctuation character.",
+E                   "detail": "The password provided is missing a punctuation character."
+E               },
+E               {
+E                   "code": "226",
+E                   "source": {
+E                       "pointer": "/data/attributes/password"
+E                   },
+E                   "title": "Password and password confirmation do not match."
+E               }
+E           ]
+E       }] Expected key <sauce> to be in dict keys at path depth 2 but was not.
 ```
 
 ### Failure

--- a/README.md
+++ b/README.md
@@ -708,6 +708,48 @@ assert_that(fred).has_first_name('Fred')
 assert_that(fred).has_last_name('Smith')
 ```
 
+### Key Path Extractions
+
+It is frequently necessary to test a value, residing deep in a blob, API json response, or similar structure, using a specific key path. 
+Such blobs are often made up of list-like, dict-like and user-defined-objects combinations. The `assertpy` library provides an `extract_path()` method.
+
+Given such a blob: 
+
+```py
+example_nested_blob = [
+    True, False, {
+        'anything_1': ('a', 'b', 'c'),
+        'instance': SomeUserDefinedClass(
+            name='Fred',
+            age=32,
+            children={
+                'Bob': 3,
+                'Alice': 5,
+            }
+        ),
+        'anything_2': 66
+    }, None,
+]
+```
+
+We can extract deep nested values, with given key paths, for testing directly, saving or chaining, as such:
+
+```py
+assert_that(example_nested_blob).extract_path(1).is_false()
+assert_that(example_nested_blob).extract_path(2, 'anything_1').is_length(3).extract_path(1).is_equal_to('b')
+assert_that(example_nested_blob).extract_path(2, 'anything_2').is_equal_to(66)
+assert_that(example_nested_blob).extract_path(2, 'instance', 'name').is_equal_to('Fred')
+assert_that(example_nested_blob).extract_path(2, 'instance', 'children').has_Bob(3).has_Alice(5)
+```
+
+Simultaneously any discrepancies between the given path and value structure will be reported and runtime errors will be avoided.
+For example a typo in attribute name `children` will produce:
+ 
+```
+>       assert_that(example_nested_blob).extract_path(2, 'instance', 'Children', 'Bob').is_equal_to(3)
+E       ValueError: invalid extraction key <Children> for value at path depth 2
+```
+
 ### Failure
 
 The `assertpy` library includes a `fail()` method to explicitly force a test failure.  It can be used like this:

--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ For example a typo in attribute name `children` will produce:
  
 ```
 >       assert_that(example_nested_blob).extract_path(2, 'instance', 'Children', 'Bob').is_equal_to(3)
-E       ValueError: invalid extraction key <Children> for value at path depth 2
+E       AssertionError: invalid extraction key <Children> for value at path depth 2
 ```
 
 ### Failure

--- a/assertpy/assertpy.py
+++ b/assertpy/assertpy.py
@@ -41,6 +41,7 @@ from .contains import ContainsMixin
 from .date import DateMixin
 from .dict import DictMixin
 from .dynamic import DynamicMixin
+from .extract_path import ExtractPathMixin
 from .extracting import ExtractingMixin
 from .exception import ExceptionMixin
 from .file import FileMixin
@@ -64,6 +65,7 @@ ASSERTPY_FILES = [os.path.join('assertpy', file) for file in [
     'dict.py',
     'dynamic.py',
     'exception.py',
+    'extract_path.py',
     'extracting.py',
     'file.py',
     'helpers.py',
@@ -380,6 +382,7 @@ class AssertionBuilder(
     NumericMixin,
     HelpersMixin,
     FileMixin,
+    ExtractPathMixin,
     ExtractingMixin,
     ExceptionMixin,
     DynamicMixin,

--- a/assertpy/extract_path.py
+++ b/assertpy/extract_path.py
@@ -114,17 +114,17 @@ class ExtractPathMixin(object):
         for path_depth, key in enumerate(keys):
             if isinstance(key, int) and isinstance(self.val, (list, tuple, range)):
                 if not -len(self.val) <= key < len(self.val):
-                    raise ValueError('index <%i> is out of value range at path depth %i' % (key, path_depth))
+                    self.error('index <%i> is out of value range at path depth %i' % (key, path_depth))
                 self.val = self.val[key]
             elif isinstance(key, Hashable) and self._check_dict_like(self.val, return_as_bool=True): # isinstance(self.val, dict):
                 try:
                     self.val = self.val[key]
                 except KeyError:
-                    raise ValueError('key <%s> is not in dict keys at path depth %i' % (key, path_depth))
+                    self.error('key <%s> is not in dict keys at path depth %i' % (key, path_depth))
             elif isinstance(key, str) and hasattr(self.val, key):
                 self.val = eval(f'self.val.{key}')
             else:
-                raise ValueError('invalid extraction key <%s> for value at path depth %i' % (key, path_depth))
+                self.error('invalid extraction key <%s> for value at path depth %i' % (key, path_depth))
 
         return self
 

--- a/assertpy/extract_path.py
+++ b/assertpy/extract_path.py
@@ -99,7 +99,7 @@ class ExtractPathMixin(object):
                 assert_that(example_nested_blob).extract_path(2, 'instance', 'name').is_equal_to('Fred')
                 assert_that(example_nested_blob).extract_path(2, 'instance', 'children').has_Bob(3).has_Alice(5)
 
-            Works with list, tuple, dict, user-object types.
+            Works with list/tuple/range, dict-like & user-object types.
 
             Allows chaining extractions while doing validations along the path::
 
@@ -116,10 +116,11 @@ class ExtractPathMixin(object):
                 if not -len(self.val) <= key < len(self.val):
                     raise ValueError('index <%i> is out of value range at path depth %i' % (key, path_depth))
                 self.val = self.val[key]
-            elif isinstance(key, Hashable) and isinstance(self.val, dict):
-                if key not in self.val:
+            elif isinstance(key, Hashable) and self._check_dict_like(self.val, return_as_bool=True): # isinstance(self.val, dict):
+                try:
+                    self.val = self.val[key]
+                except KeyError:
                     raise ValueError('key <%s> is not in dict keys at path depth %i' % (key, path_depth))
-                self.val = self.val[key]
             elif isinstance(key, str) and hasattr(self.val, key):
                 self.val = eval(f'self.val.{key}')
             else:

--- a/assertpy/extract_path.py
+++ b/assertpy/extract_path.py
@@ -52,7 +52,7 @@ class ExtractPathMixin(object):
         example_nested_blob = [
             True, False, {
                 'anything_1': ('a', 'b', 'c'),
-                'instance': ExampleClass(
+                'instance': SomeUserDefinedClass(
                     name='Fred',
                     age=32,
                     children={
@@ -82,7 +82,7 @@ class ExtractPathMixin(object):
                 example_nested_blob = [
                     True, False, {
                         'anything_1': ('a', 'b', 'c'),
-                        'instance': ExampleClass(
+                        'instance': SomeUserDefinedClass(
                             name='Fred',
                             age=32,
                             children={

--- a/assertpy/extract_path.py
+++ b/assertpy/extract_path.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2015-2019, Activision Publishing, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+import collections
+from typing import Hashable
+
+if sys.version_info[0] == 3:
+    str_types = (str,)
+    Iterable = collections.abc.Iterable
+else:
+    str_types = (basestring,)
+    Iterable = collections.Iterable
+
+__tracebackhide__ = True
+
+
+class ExtractPathMixin(object):
+    """
+    Path extracting mixin.
+    """
+    def extract_path(self, *keys):
+        """
+        Extracts element at path pointed by keys, from object value.
+        Verifies each key validity and presence.
+        """
+        for path_depth, key in enumerate(keys):
+            if isinstance(key, int) and isinstance(self.val, (list, tuple, range)):
+                if not -len(self.val) <= key < len(self.val):
+                    raise ValueError('index <%i> is out of value range at path depth %i' % (key, path_depth))
+                self.val = self.val[key]
+            elif isinstance(key, Hashable) and isinstance(self.val, dict):
+                if key not in self.val:
+                    raise ValueError('key <%s> is not in dict keys at path depth %i' % (key, path_depth))
+                self.val = self.val[key]
+            elif isinstance(key, str) and hasattr(self.val, key):
+                self.val = eval(f'self.val.{key}')
+            else:
+                raise ValueError('invalid extraction key <%s> for value at path depth %i' % (key, path_depth))
+
+        return self
+
+

--- a/assertpy/extract_path.py
+++ b/assertpy/extract_path.py
@@ -114,17 +114,17 @@ class ExtractPathMixin(object):
         for path_depth, key in enumerate(keys):
             if isinstance(key, int) and isinstance(self.val, (list, tuple, range)):
                 if not -len(self.val) <= key < len(self.val):
-                    self.error('index <%i> is out of value range at path depth %i' % (key, path_depth))
+                    self.error('Expected index <%i> to be in range of iterable value at path depth %i, but was not.' % (key, path_depth))
                 self.val = self.val[key]
             elif isinstance(key, Hashable) and self._check_dict_like(self.val, return_as_bool=True): # isinstance(self.val, dict):
                 try:
                     self.val = self.val[key]
                 except KeyError:
-                    self.error('key <%s> is not in dict keys at path depth %i' % (key, path_depth))
+                    self.error('Expected key <%s> to be in dict keys of value at path depth %i, but was not.' % (key, path_depth))
             elif isinstance(key, str) and hasattr(self.val, key):
                 self.val = eval(f'self.val.{key}')
             else:
-                self.error('invalid extraction key <%s> for value at path depth %i' % (key, path_depth))
+                self.error('Expected key <%s> to be valid extraction key for value at path depth %i, but was not.' % (key, path_depth))
 
         return self
 

--- a/assertpy/extract_path.py
+++ b/assertpy/extract_path.py
@@ -122,7 +122,7 @@ class ExtractPathMixin(object):
                 except KeyError:
                     self.error('Expected key <%s> to be in dict keys of value at path depth %i, but was not.' % (key, path_depth))
             elif isinstance(key, str) and hasattr(self.val, key):
-                self.val = eval(f'self.val.{key}')
+                self.val = getattr(self.val, key)
             else:
                 self.error('Expected key <%s> to be valid extraction key for value at path depth %i, but was not.' % (key, path_depth))
 

--- a/tests/test_extract_path.py
+++ b/tests/test_extract_path.py
@@ -43,7 +43,6 @@ class TestExtractPathMethodWithLists:
         assert_that(example_iterable).extract_path(2).is_equal_to(3)
         assert_that(example_iterable).extract_path().is_equal_to(example_iterable)
 
-
     def test_iterable_extraction_neg_index(self, example_iterable):
         assert_that(example_iterable).extract_path(-1).is_equal_to(3)
         assert_that(example_iterable).extract_path(-3).is_equal_to(1)
@@ -125,7 +124,6 @@ class TestExtractPathMethodWithUserDefinedObjects:
         assert_that(example_obj).extract_path('children').has_Bob(3).has_Alice(5).does_not_contain('name', 'age')
         assert_that(example_obj).extract_path().is_equal_to(example_obj)
 
-
     @mark.parametrize('invalid_field', ['Age', 0, None])
     def test_obj_extraction_invalid_field_failure(self, invalid_field):
         try:
@@ -144,9 +142,9 @@ example_nested_blob = [
 ]
 
 
-class TestExtractPathMethodWithNestedMixedTypeBobs:
+class TestExtractPathMethodWithNestedMixedTypeBlobs:
     def test_nested_obj_extraction(self):
-        assert_that(example_nested_blob).extract_path(1).is_equal_to(False)
+        assert_that(example_nested_blob).extract_path(1).is_false()
         assert_that(example_nested_blob).extract_path(2, 'anything_2').is_equal_to(66)
         assert_that(example_nested_blob).extract_path(2, 'instance', 'name').is_equal_to('Fred')
         assert_that(example_nested_blob).extract_path(2, 'instance', 'children').has_Bob(3).has_Alice(5)
@@ -162,14 +160,12 @@ class TestExtractPathMethodWithNestedMixedTypeBobs:
         except ValueError as ex:
             assert_that(str(ex)).is_equal_to('invalid extraction key <instance> for value at path depth 1')
 
-
     def test_nested_obj_extraction_depth_1_invalid_key_failure(self):
         try:
             assert_that(example_nested_blob).extract_path(2, 'instances', 'name')
             fail('should have raised error')
         except ValueError as ex:
             assert_that(str(ex)).is_equal_to('key <instances> is not in dict keys at path depth 1')
-
 
     def test_nested_obj_extraction_depth_2_invalid_key_failure(self):
         try:

--- a/tests/test_extract_path.py
+++ b/tests/test_extract_path.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2015-2019, Activision Publishing, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from assertpy import assert_that, fail
+from pytest import mark, param
+
+
+@mark.parametrize('example_iterable', [
+    param([1, 2, 3], id='list'),
+    param((1, 2, 3), id='tuple'),
+    param(range(1, 4), id='range'),
+])
+class TestExtractMethodWithLists:
+    def test_iterable_extraction(self, example_iterable):
+        assert_that(example_iterable).extract_path(0).is_equal_to(1)
+        assert_that(example_iterable).extract_path(2).is_equal_to(3)
+        assert_that(example_iterable).extract_path().is_equal_to(example_iterable)
+
+
+    def test_iterable_extraction_neg_index(self, example_iterable):
+        assert_that(example_iterable).extract_path(-1).is_equal_to(3)
+        assert_that(example_iterable).extract_path(-3).is_equal_to(1)
+
+    def test_iterable_extraction_pos_index_bounds_failure(self, example_iterable):
+        try:
+            assert_that(example_iterable).extract_path(3)
+            fail('should have raised error')
+        except ValueError as ex:
+            assert_that(str(ex)).is_equal_to('index <3> is out of value range at path depth 0')
+
+    def test_iterable_extraction_neg_index_bounds_failure(self, example_iterable):
+        try:
+            assert_that(example_iterable).extract_path(-4)
+            fail('should have raised error')
+        except ValueError as ex:
+            assert_that(str(ex)).is_equal_to('index <-4> is out of value range at path depth 0')
+
+    def test_iterable_extraction_invalid_str_index_failure(self, example_iterable):
+        try:
+            assert_that(example_iterable).extract_path('1')
+            fail('should have raised error')
+        except ValueError as ex:
+            assert_that(str(ex)).is_equal_to('invalid extraction key <1> for value at path depth 0')
+
+    def test_iterable_extraction_invalid_none_index_failure(self, example_iterable):
+        try:
+            assert_that(example_iterable).extract_path(None)
+            fail('should have raised error')
+        except ValueError as ex:
+            assert_that(str(ex)).is_equal_to('invalid extraction key <None> for value at path depth 0')
+
+
+def test_dict_extraction():
+    assert_that({'1': 1, '2': 2, '3': 3}).extract_path('1').is_equal_to(1)
+    assert_that ({'1': 1, '2': 2, '3': 3}).extract_path('3').is_equal_to(3)
+    assert_that ({None: 1, '2': 2, '3': 3}).extract_path(None).is_equal_to(1)
+    assert_that ({'1': 1, 55: 2, '3': 3}).extract_path(55).is_equal_to(2)
+    assert_that({'1': 1, '2': 2, '3': 3}).extract_path().is_equal_to({'1': 1, '2': 2, '3': 3})
+
+
+@mark.parametrize('invalid_key', [0, '4', None])
+def test_dict_extraction_invalid_key_failure(invalid_key):
+    try:
+        assert_that({'1': 1, '2': 2, '3': 3}).extract_path(invalid_key)
+        fail('should have raised error')
+    except ValueError as ex:
+        assert_that(str(ex)).is_equal_to('key <%s> is not in dict keys at path depth 0' % invalid_key)
+
+
+class ExampleClass:
+    def __init__(self, name: str, age: int, children: dict):
+        self.name = name
+        self.age = age
+        self.children = children
+
+
+example_obj = ExampleClass(
+    name='Fred',
+    age=32,
+    children={
+        'Bob': 3,
+        'Alice': 5
+    }
+)
+example_nested_obj = [
+    1,
+    2,
+    {
+        'anything_1': 55,
+        'instance': ExampleClass(
+            name='Fred',
+            age=32,
+            children={
+                'Bob': 3,
+                'Alice': 5,
+            }
+        ),
+        'anything_2': 66
+    },
+    4
+]
+
+
+def test_obj_extraction():
+    assert_that(example_obj).extract_path('name').is_equal_to('Fred')
+    assert_that(example_obj).extract_path('age').is_equal_to(32)
+    assert_that(example_obj).extract_path('children').has_Bob(3).has_Alice(5).does_not_contain('name', 'age')
+    assert_that(example_obj).extract_path().is_equal_to(example_obj)
+
+
+@mark.parametrize('invalid_field', ['Age', 0, None])
+def test_obj_extraction_invalid_field_failure(invalid_field):
+    try:
+        assert_that(example_obj).extract_path(invalid_field)
+        fail('should have raised error')
+    except ValueError as ex:
+        assert_that(str(ex)).is_equal_to('invalid extraction key <%s> for value at path depth 0' % invalid_field)
+
+
+def test_nested_obj_extraction():
+    assert_that(example_nested_obj).extract_path(2, 'instance', 'name').is_equal_to('Fred')
+    assert_that(example_nested_obj).extract_path(2, 'instance', 'children').has_Bob(3).has_Alice(5)
+    assert_that(example_nested_obj).extract_path(2, 'instance', 'children').does_not_contain('name', 'age')
+
+
+def test_nested_obj_extraction_path_end_failure():
+    try:
+        assert_that(example_nested_obj).extract_path(1, 'instance', 'name')
+        fail('should have raised error')
+    except ValueError as ex:
+        assert_that(str(ex)).is_equal_to('invalid extraction key <instance> for value at path depth 1')
+
+
+def test_nested_obj_extraction_depth_1_invalid_key_failure():
+    try:
+        assert_that(example_nested_obj).extract_path(2, 'instances', 'name')
+        fail('should have raised error')
+    except ValueError as ex:
+        assert_that(str(ex)).is_equal_to('key <instances> is not in dict keys at path depth 1')
+
+
+def test_nested_obj_extraction_depth_2_invalid_key_failure():
+    try:
+        assert_that(example_nested_obj).extract_path(2, 'instance', 'names')
+        fail('should have raised error')
+    except ValueError as ex:
+        assert_that(str(ex)).is_equal_to('invalid extraction key <names> for value at path depth 2')

--- a/tests/test_extract_path.py
+++ b/tests/test_extract_path.py
@@ -35,7 +35,7 @@ from pytest import mark, param
     param((1, 2, 3), id='tuple'),
     param(range(1, 4), id='range'),
 ])
-class TestExtractMethodWithLists:
+class TestExtractPathMethodWithLists:
     def test_iterable_extraction(self, example_iterable):
         assert_that(example_iterable).extract_path(0).is_equal_to(1)
         assert_that(example_iterable).extract_path(2).is_equal_to(3)
@@ -75,21 +75,22 @@ class TestExtractMethodWithLists:
             assert_that(str(ex)).is_equal_to('invalid extraction key <None> for value at path depth 0')
 
 
-def test_dict_extraction():
-    assert_that({'1': 1, '2': 2, '3': 3}).extract_path('1').is_equal_to(1)
-    assert_that ({'1': 1, '2': 2, '3': 3}).extract_path('3').is_equal_to(3)
-    assert_that ({None: 1, '2': 2, '3': 3}).extract_path(None).is_equal_to(1)
-    assert_that ({'1': 1, 55: 2, '3': 3}).extract_path(55).is_equal_to(2)
-    assert_that({'1': 1, '2': 2, '3': 3}).extract_path().is_equal_to({'1': 1, '2': 2, '3': 3})
+class TestExtractPathMethodWithDictionaries:
+    def test_dict_extraction(self, ):
+        assert_that({'1': 1, '2': 2, '3': 3}).extract_path('1').is_equal_to(1)
+        assert_that ({'1': 1, '2': 2, '3': 3}).extract_path('3').is_equal_to(3)
+        assert_that ({None: 1, '2': 2, '3': 3}).extract_path(None).is_equal_to(1)
+        assert_that ({'1': 1, 55: 2, '3': 3}).extract_path(55).is_equal_to(2)
+        assert_that({'1': 1, '2': 2, '3': 3}).extract_path().is_equal_to({'1': 1, '2': 2, '3': 3})
 
 
-@mark.parametrize('invalid_key', [0, '4', None])
-def test_dict_extraction_invalid_key_failure(invalid_key):
-    try:
-        assert_that({'1': 1, '2': 2, '3': 3}).extract_path(invalid_key)
-        fail('should have raised error')
-    except ValueError as ex:
-        assert_that(str(ex)).is_equal_to('key <%s> is not in dict keys at path depth 0' % invalid_key)
+    @mark.parametrize('invalid_key', [0, '4', None])
+    def test_dict_extraction_invalid_key_failure(self, invalid_key):
+        try:
+            assert_that({'1': 1, '2': 2, '3': 3}).extract_path(invalid_key)
+            fail('should have raised error')
+        except ValueError as ex:
+            assert_that(str(ex)).is_equal_to('key <%s> is not in dict keys at path depth 0' % invalid_key)
 
 
 class ExampleClass:
@@ -123,49 +124,51 @@ example_nested_blob = [
 ]
 
 
-def test_obj_extraction():
-    assert_that(example_obj).extract_path('name').is_equal_to('Fred')
-    assert_that(example_obj).extract_path('age').is_equal_to(32)
-    assert_that(example_obj).extract_path('children').has_Bob(3).has_Alice(5).does_not_contain('name', 'age')
-    assert_that(example_obj).extract_path().is_equal_to(example_obj)
+class TestExtractPathMethodWithUserDefinedObjects:
+    def test_obj_extraction(self, ):
+        assert_that(example_obj).extract_path('name').is_equal_to('Fred')
+        assert_that(example_obj).extract_path('age').is_equal_to(32)
+        assert_that(example_obj).extract_path('children').has_Bob(3).has_Alice(5).does_not_contain('name', 'age')
+        assert_that(example_obj).extract_path().is_equal_to(example_obj)
 
 
-@mark.parametrize('invalid_field', ['Age', 0, None])
-def test_obj_extraction_invalid_field_failure(invalid_field):
-    try:
-        assert_that(example_obj).extract_path(invalid_field)
-        fail('should have raised error')
-    except ValueError as ex:
-        assert_that(str(ex)).is_equal_to('invalid extraction key <%s> for value at path depth 0' % invalid_field)
+    @mark.parametrize('invalid_field', ['Age', 0, None])
+    def test_obj_extraction_invalid_field_failure(self, invalid_field):
+        try:
+            assert_that(example_obj).extract_path(invalid_field)
+            fail('should have raised error')
+        except ValueError as ex:
+            assert_that(str(ex)).is_equal_to('invalid extraction key <%s> for value at path depth 0' % invalid_field)
 
 
-def test_nested_obj_extraction():
-    assert_that(example_nested_blob).extract_path(1).is_equal_to(2)
-    assert_that(example_nested_blob).extract_path(2, 'anything_2').is_equal_to(66)
-    assert_that(example_nested_blob).extract_path(2, 'instance', 'name').is_equal_to('Fred')
-    assert_that(example_nested_blob).extract_path(2, 'instance', 'children').has_Bob(3).has_Alice(5)
-    assert_that(example_nested_blob).extract_path(2, 'instance', 'children').does_not_contain('name', 'age')
+class TestExtractPathMethodWithNestedMixedTypeBobs:
+    def test_nested_obj_extraction(self):
+        assert_that(example_nested_blob).extract_path(1).is_equal_to(2)
+        assert_that(example_nested_blob).extract_path(2, 'anything_2').is_equal_to(66)
+        assert_that(example_nested_blob).extract_path(2, 'instance', 'name').is_equal_to('Fred')
+        assert_that(example_nested_blob).extract_path(2, 'instance', 'children').has_Bob(3).has_Alice(5)
+        assert_that(example_nested_blob).extract_path(2, 'instance', 'children').does_not_contain('name', 'age')
 
 
-def test_nested_obj_extraction_path_end_failure():
-    try:
-        assert_that(example_nested_blob).extract_path(1, 'instance', 'name')
-        fail('should have raised error')
-    except ValueError as ex:
-        assert_that(str(ex)).is_equal_to('invalid extraction key <instance> for value at path depth 1')
+    def test_nested_obj_extraction_path_end_failure(self):
+        try:
+            assert_that(example_nested_blob).extract_path(1, 'instance', 'name')
+            fail('should have raised error')
+        except ValueError as ex:
+            assert_that(str(ex)).is_equal_to('invalid extraction key <instance> for value at path depth 1')
 
 
-def test_nested_obj_extraction_depth_1_invalid_key_failure():
-    try:
-        assert_that(example_nested_blob).extract_path(2, 'instances', 'name')
-        fail('should have raised error')
-    except ValueError as ex:
-        assert_that(str(ex)).is_equal_to('key <instances> is not in dict keys at path depth 1')
+    def test_nested_obj_extraction_depth_1_invalid_key_failure(self):
+        try:
+            assert_that(example_nested_blob).extract_path(2, 'instances', 'name')
+            fail('should have raised error')
+        except ValueError as ex:
+            assert_that(str(ex)).is_equal_to('key <instances> is not in dict keys at path depth 1')
 
 
-def test_nested_obj_extraction_depth_2_invalid_key_failure():
-    try:
-        assert_that(example_nested_blob).extract_path(2, 'instance', 'names')
-        fail('should have raised error')
-    except ValueError as ex:
-        assert_that(str(ex)).is_equal_to('invalid extraction key <names> for value at path depth 2')
+    def test_nested_obj_extraction_depth_2_invalid_key_failure(self):
+        try:
+            assert_that(example_nested_blob).extract_path(2, 'instance', 'names')
+            fail('should have raised error')
+        except ValueError as ex:
+            assert_that(str(ex)).is_equal_to('invalid extraction key <names> for value at path depth 2')

--- a/tests/test_extract_path.py
+++ b/tests/test_extract_path.py
@@ -107,10 +107,8 @@ example_obj = ExampleClass(
         'Alice': 5
     }
 )
-example_nested_obj = [
-    1,
-    2,
-    {
+example_nested_blob = [
+    1, 2, {
         'anything_1': 55,
         'instance': ExampleClass(
             name='Fred',
@@ -121,8 +119,7 @@ example_nested_obj = [
             }
         ),
         'anything_2': 66
-    },
-    4
+    }, 4
 ]
 
 
@@ -143,14 +140,16 @@ def test_obj_extraction_invalid_field_failure(invalid_field):
 
 
 def test_nested_obj_extraction():
-    assert_that(example_nested_obj).extract_path(2, 'instance', 'name').is_equal_to('Fred')
-    assert_that(example_nested_obj).extract_path(2, 'instance', 'children').has_Bob(3).has_Alice(5)
-    assert_that(example_nested_obj).extract_path(2, 'instance', 'children').does_not_contain('name', 'age')
+    assert_that(example_nested_blob).extract_path(1).is_equal_to(2)
+    assert_that(example_nested_blob).extract_path(2, 'anything_2').is_equal_to(66)
+    assert_that(example_nested_blob).extract_path(2, 'instance', 'name').is_equal_to('Fred')
+    assert_that(example_nested_blob).extract_path(2, 'instance', 'children').has_Bob(3).has_Alice(5)
+    assert_that(example_nested_blob).extract_path(2, 'instance', 'children').does_not_contain('name', 'age')
 
 
 def test_nested_obj_extraction_path_end_failure():
     try:
-        assert_that(example_nested_obj).extract_path(1, 'instance', 'name')
+        assert_that(example_nested_blob).extract_path(1, 'instance', 'name')
         fail('should have raised error')
     except ValueError as ex:
         assert_that(str(ex)).is_equal_to('invalid extraction key <instance> for value at path depth 1')
@@ -158,7 +157,7 @@ def test_nested_obj_extraction_path_end_failure():
 
 def test_nested_obj_extraction_depth_1_invalid_key_failure():
     try:
-        assert_that(example_nested_obj).extract_path(2, 'instances', 'name')
+        assert_that(example_nested_blob).extract_path(2, 'instances', 'name')
         fail('should have raised error')
     except ValueError as ex:
         assert_that(str(ex)).is_equal_to('key <instances> is not in dict keys at path depth 1')
@@ -166,7 +165,7 @@ def test_nested_obj_extraction_depth_1_invalid_key_failure():
 
 def test_nested_obj_extraction_depth_2_invalid_key_failure():
     try:
-        assert_that(example_nested_obj).extract_path(2, 'instance', 'names')
+        assert_that(example_nested_blob).extract_path(2, 'instance', 'names')
         fail('should have raised error')
     except ValueError as ex:
         assert_that(str(ex)).is_equal_to('invalid extraction key <names> for value at path depth 2')

--- a/tests/test_extract_path.py
+++ b/tests/test_extract_path.py
@@ -25,6 +25,8 @@
 # ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from collections import defaultdict, ChainMap, OrderedDict
+from types import MappingProxyType
 
 from assertpy import assert_that, fail
 from pytest import mark, param
@@ -83,6 +85,12 @@ class TestExtractPathMethodWithDictionaries:
         assert_that ({'1': 1, 55: 2, '3': 3}).extract_path(55).is_equal_to(2)
         assert_that({'1': 1, '2': 2, '3': 3}).extract_path().is_equal_to({'1': 1, '2': 2, '3': 3})
 
+    def test_dict_like_extraction(self):
+        assert_that(defaultdict(int, {'1': 1})).extract_path('1').is_equal_to(1)
+        assert_that(defaultdict(int, {'1': 1})).extract_path('2').is_equal_to(0)
+        assert_that(ChainMap({'a': 1}, {'b': 2})).extract_path('b').is_equal_to(2)
+        assert_that(OrderedDict([('a', 1), ('b', 2)])).extract_path('b').is_equal_to(2)
+        assert_that(MappingProxyType({'a': 1, 'b': 2})).extract_path('b').is_equal_to(2)
 
     @mark.parametrize('invalid_key', [0, '4', None])
     def test_dict_extraction_invalid_key_failure(self, invalid_key):

--- a/tests/test_extract_path.py
+++ b/tests/test_extract_path.py
@@ -25,6 +25,7 @@
 # ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 from collections import defaultdict, ChainMap, OrderedDict
 from types import MappingProxyType
 
@@ -52,28 +53,28 @@ class TestExtractPathMethodWithLists:
             assert_that(example_iterable).extract_path(3)
             fail('should have raised error')
         except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('index <3> is out of value range at path depth 0')
+            assert_that(str(ex)).is_equal_to('Expected index <3> to be in range of iterable value at path depth 0, but was not.')
 
     def test_iterable_extraction_neg_index_bounds_failure(self, example_iterable):
         try:
             assert_that(example_iterable).extract_path(-4)
             fail('should have raised error')
         except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('index <-4> is out of value range at path depth 0')
+            assert_that(str(ex)).is_equal_to('Expected index <-4> to be in range of iterable value at path depth 0, but was not.')
 
     def test_iterable_extraction_invalid_str_index_failure(self, example_iterable):
         try:
             assert_that(example_iterable).extract_path('1')
             fail('should have raised error')
         except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('invalid extraction key <1> for value at path depth 0')
+            assert_that(str(ex)).is_equal_to('Expected key <1> to be valid extraction key for value at path depth 0, but was not.')
 
     def test_iterable_extraction_invalid_none_index_failure(self, example_iterable):
         try:
             assert_that(example_iterable).extract_path(None)
             fail('should have raised error')
         except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('invalid extraction key <None> for value at path depth 0')
+            assert_that(str(ex)).is_equal_to('Expected key <None> to be valid extraction key for value at path depth 0, but was not.')
 
 
 class TestExtractPathMethodWithDictionaries:
@@ -97,7 +98,7 @@ class TestExtractPathMethodWithDictionaries:
             assert_that({'1': 1, '2': 2, '3': 3}).extract_path(invalid_key)
             fail('should have raised error')
         except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('key <%s> is not in dict keys at path depth 0' % invalid_key)
+            assert_that(str(ex)).is_equal_to('Expected key <%s> to be in dict keys of value at path depth 0, but was not.' % invalid_key)
 
 
 class ExampleClass:
@@ -130,7 +131,7 @@ class TestExtractPathMethodWithUserDefinedObjects:
             assert_that(example_obj).extract_path(invalid_field)
             fail('should have raised error')
         except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('invalid extraction key <%s> for value at path depth 0' % invalid_field)
+            assert_that(str(ex)).is_equal_to('Expected key <%s> to be valid extraction key for value at path depth 0, but was not.' % invalid_field)
 
 
 example_nested_blob = [
@@ -158,18 +159,18 @@ class TestExtractPathMethodWithNestedMixedTypeBlobs:
             assert_that(example_nested_blob).extract_path(1, 'instance', 'name')
             fail('should have raised error')
         except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('invalid extraction key <instance> for value at path depth 1')
+            assert_that(str(ex)).is_equal_to('Expected key <instance> to be valid extraction key for value at path depth 1, but was not.')
 
     def test_nested_obj_extraction_depth_1_invalid_key_failure(self):
         try:
             assert_that(example_nested_blob).extract_path(2, 'instances', 'name')
             fail('should have raised error')
         except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('key <instances> is not in dict keys at path depth 1')
+            assert_that(str(ex)).is_equal_to('Expected key <instances> to be in dict keys of value at path depth 1, but was not.')
 
     def test_nested_obj_extraction_depth_2_invalid_key_failure(self):
         try:
             assert_that(example_nested_blob).extract_path(2, 'instance', 'names')
             fail('should have raised error')
         except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('invalid extraction key <names> for value at path depth 2')
+            assert_that(str(ex)).is_equal_to('Expected key <names> to be valid extraction key for value at path depth 2, but was not.')

--- a/tests/test_extract_path.py
+++ b/tests/test_extract_path.py
@@ -51,28 +51,28 @@ class TestExtractPathMethodWithLists:
         try:
             assert_that(example_iterable).extract_path(3)
             fail('should have raised error')
-        except ValueError as ex:
+        except AssertionError as ex:
             assert_that(str(ex)).is_equal_to('index <3> is out of value range at path depth 0')
 
     def test_iterable_extraction_neg_index_bounds_failure(self, example_iterable):
         try:
             assert_that(example_iterable).extract_path(-4)
             fail('should have raised error')
-        except ValueError as ex:
+        except AssertionError as ex:
             assert_that(str(ex)).is_equal_to('index <-4> is out of value range at path depth 0')
 
     def test_iterable_extraction_invalid_str_index_failure(self, example_iterable):
         try:
             assert_that(example_iterable).extract_path('1')
             fail('should have raised error')
-        except ValueError as ex:
+        except AssertionError as ex:
             assert_that(str(ex)).is_equal_to('invalid extraction key <1> for value at path depth 0')
 
     def test_iterable_extraction_invalid_none_index_failure(self, example_iterable):
         try:
             assert_that(example_iterable).extract_path(None)
             fail('should have raised error')
-        except ValueError as ex:
+        except AssertionError as ex:
             assert_that(str(ex)).is_equal_to('invalid extraction key <None> for value at path depth 0')
 
 
@@ -96,7 +96,7 @@ class TestExtractPathMethodWithDictionaries:
         try:
             assert_that({'1': 1, '2': 2, '3': 3}).extract_path(invalid_key)
             fail('should have raised error')
-        except ValueError as ex:
+        except AssertionError as ex:
             assert_that(str(ex)).is_equal_to('key <%s> is not in dict keys at path depth 0' % invalid_key)
 
 
@@ -129,7 +129,7 @@ class TestExtractPathMethodWithUserDefinedObjects:
         try:
             assert_that(example_obj).extract_path(invalid_field)
             fail('should have raised error')
-        except ValueError as ex:
+        except AssertionError as ex:
             assert_that(str(ex)).is_equal_to('invalid extraction key <%s> for value at path depth 0' % invalid_field)
 
 
@@ -157,19 +157,19 @@ class TestExtractPathMethodWithNestedMixedTypeBlobs:
         try:
             assert_that(example_nested_blob).extract_path(1, 'instance', 'name')
             fail('should have raised error')
-        except ValueError as ex:
+        except AssertionError as ex:
             assert_that(str(ex)).is_equal_to('invalid extraction key <instance> for value at path depth 1')
 
     def test_nested_obj_extraction_depth_1_invalid_key_failure(self):
         try:
             assert_that(example_nested_blob).extract_path(2, 'instances', 'name')
             fail('should have raised error')
-        except ValueError as ex:
+        except AssertionError as ex:
             assert_that(str(ex)).is_equal_to('key <instances> is not in dict keys at path depth 1')
 
     def test_nested_obj_extraction_depth_2_invalid_key_failure(self):
         try:
             assert_that(example_nested_blob).extract_path(2, 'instance', 'names')
             fail('should have raised error')
-        except ValueError as ex:
+        except AssertionError as ex:
             assert_that(str(ex)).is_equal_to('invalid extraction key <names> for value at path depth 2')

--- a/tests/test_extract_path.py
+++ b/tests/test_extract_path.py
@@ -108,20 +108,6 @@ example_obj = ExampleClass(
         'Alice': 5
     }
 )
-example_nested_blob = [
-    1, 2, {
-        'anything_1': 55,
-        'instance': ExampleClass(
-            name='Fred',
-            age=32,
-            children={
-                'Bob': 3,
-                'Alice': 5,
-            }
-        ),
-        'anything_2': 66
-    }, 4
-]
 
 
 class TestExtractPathMethodWithUserDefinedObjects:
@@ -141,14 +127,25 @@ class TestExtractPathMethodWithUserDefinedObjects:
             assert_that(str(ex)).is_equal_to('invalid extraction key <%s> for value at path depth 0' % invalid_field)
 
 
+example_nested_blob = [
+    True, False, {
+        'anything_1': ('a', 'b', 'c'),
+        'instance': example_obj,
+        'anything_2': 66
+    }, None,
+]
+
+
 class TestExtractPathMethodWithNestedMixedTypeBobs:
     def test_nested_obj_extraction(self):
-        assert_that(example_nested_blob).extract_path(1).is_equal_to(2)
+        assert_that(example_nested_blob).extract_path(1).is_equal_to(False)
         assert_that(example_nested_blob).extract_path(2, 'anything_2').is_equal_to(66)
         assert_that(example_nested_blob).extract_path(2, 'instance', 'name').is_equal_to('Fred')
         assert_that(example_nested_blob).extract_path(2, 'instance', 'children').has_Bob(3).has_Alice(5)
         assert_that(example_nested_blob).extract_path(2, 'instance', 'children').does_not_contain('name', 'age')
 
+    def test_nested_obj_chained_extractions(self):
+        assert_that(example_nested_blob).extract_path(2, 'anything_1').is_length(3).extract_path(1).is_equal_to('b')
 
     def test_nested_obj_extraction_path_end_failure(self):
         try:


### PR DESCRIPTION
## Description
Assertpy has been central in building multiple Python API test frameworks. The systems under test can have 
differing underlying implementation details. Rest, websocket, databases, are some common examples.   

It is quite regular for these frameworks to make calls and receive responses in json or other similar formats, which are returned as mixed type blobs by client implementations. In some cases these blobs can contain user defined objects as well.

In such environments, it is routine practice to validate specific entries, residing in varying response paths. All existing approaches in Python have drawbacks, like:
1. Direct element accesses &rarr; Require response schema validation or can end in runtime errors 
2. `get()`, `in`, `not in` operations &rarr; Result in cumbersome, obscure expressions, plus are missing path errors reporting 
3. `try-except` blocks &rarr; Result in verbose, tedious & hard to maintain code blocks

Only approach **1.** is a viable option, except schema validation is often redundant and even unwanted. To mention a few reasons:
- Creates dependencies among test cases. This blurring of responsibilities has a direct toll on coverage and failure reports. 
- Makes test cases rely on paths that are not always under test, not yet covered by a contract. This reduces test maintainability.
- Is often tedious to communicate, type, maintain & document.

Having proper explicit validation and reporting of path keys errors, along with values validation helps with:
- Better coverage
- Improved reporting which:
  - helps easily differentiate API errors from test code typos
  - reduces required time for error debugging
  - reduces need for rerunning failed test cases, which speeds up flaky bugs resolution

Assertpy can tackle these problems profoundly but is missing an important method. As an extention, it has been the first to implement in every test framework I have built or worked on so far. Having it built-in seems like a no-brainer. It provides clean and easy key path extractions, paired with proper reporting for any key errors in given paths. Integrated with the rest of assertpy functionalities it clearly enhances the **Fluent API** design.

---

## Examples 

#### API response:

```py
api_response = {
  "jsonapi": { "version": "1.1" },
  "errors": [
    {
      "code":   "123",
      "source": { "pointer": "/data/attributes/firstName" },
      "title":  "Value is too short",
      "detail": "First name must contain at least two characters."
    },
    {
      "code":   "225",
      "source": { "pointer": "/data/attributes/password" },
      "title": "Passwords must contain a letter, number, and punctuation character.",
      "detail": "The password provided is missing a punctuation character."
    },
    {
      "code":   "226",
      "source": { "pointer": "/data/attributes/password" },
      "title": "Password and password confirmation do not match."
    }
  ]
}
```

#### Verifications:

Single extraction:
```py
assert_that(api_response, dumps(api_response, indent=4)) \
    .extract_path('errors', 1, 'source', 'pointer') \
    .is_equal_to('/data/attributes/password')
```

Chaining with itself:
```py
assert_that(api_response, dumps(api_response, indent=4)) \
    .extract_path('errors', 1) \
    .has_code('225')\
    .extract_path('detail') \
    .contains('password')
```

Chaining with extracting
```py
assert_that(api_response, dumps(api_response, indent=4)) \
    .contains('jsonapi') \
    .extract_path('errors') \
    .extracting('source', filter=lambda x: x.get('code') and x['code'].startswith('22')) \
    .extracting('pointer') \
    .contains_only('/data/attributes/password')
```

Failure:
```
>       assert_that(api_response, dumps(api_response, indent=4)).extract_path('errors', 1, 'sauce', 'pointer').is_equal_to('/data/attributes/password')
E       AssertionError: [{
E           "jsonapi": {
E               "version": "1.1"
E           },
E           "errors": [
E               {
E                   "code": "123",
E                   "source": {
E                       "pointer": "/data/attributes/firstName"
E                   },
E                   "title": "Value is too short",
E                   "detail": "First name must contain at least two characters."
E               },
E               {
E                   "code": "225",
E                   "source": {
E                       "pointer": "/data/attributes/password"
E                   },
E                   "title": "Passwords must contain a letter, number, and punctuation character.",
E                   "detail": "The password provided is missing a punctuation character."
E               },
E               {
E                   "code": "226",
E                   "source": {
E                       "pointer": "/data/attributes/password"
E                   },
E                   "title": "Password and password confirmation do not match."
E               }
E           ]
E       }] Expected key <sauce> to be in dict keys of value at path depth 2, but was not.
```

For more usage examples see related **README** entry and **unit test** cases.
